### PR TITLE
use correct streaming api url

### DIFF
--- a/mipa/gateway.py
+++ b/mipa/gateway.py
@@ -63,7 +63,7 @@ class MisskeyWebSocket:
     ):
         try:
             socket = await client.core.http.session.ws_connect(
-                f'{client.url}?i={client.token}'
+                f'{client.url}streaming?i={client.token}'
             )
             ws = cls(socket, client)
             ws._dispatch = client.dispatch


### PR DESCRIPTION
This updates the streaming url used to match that of the Misskey API docs at https://misskey-hub.net/docs/api/streaming/

Resolves https://github.com/yupix/MiPA/issues/16